### PR TITLE
Default value bug fix && Changed minimum required iOS version

### DIFF
--- a/TOAppSettings.podspec
+++ b/TOAppSettings.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/TimOliver/TOAppSettings'
   s.author   = 'Tim Oliver'
   s.source   = { :git => 'https://github.com/TimOliver/TOAppSettings.git', :tag => s.version }
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '8.0'
   s.source_files = 'TOAppSettings/**/*.{h,m}'
   s.requires_arc = true
 end

--- a/TOAppSettings/TOAppSettings.m
+++ b/TOAppSettings/TOAppSettings.m
@@ -551,16 +551,14 @@ static inline void TOAppSettingsRegisterSubclassProperties()
     NSDictionary *defaultSettings = [[self class] defaultPropertyValues];
     if (defaultSettings.allKeys.count == 0) { return; }
     
-    // Check if there are any keys with our prefix already present (If there are, we've already done this)
-    NSString *keyPrefix = self.propertyKeyPrefix;
-    NSArray *keys = [NSUserDefaults standardUserDefaults].dictionaryRepresentation.allKeys;
-    for (NSString *key in keys) {
-        if ([key hasPrefix:keyPrefix]) { return; }
-    }
+	NSArray *keys = [NSUserDefaults standardUserDefaults].dictionaryRepresentation.allKeys;
     
     // Register each setting
     for (NSString *key in defaultSettings.allKeys) {
-        [self setValue:defaultSettings[key] forKey:key];
+		
+		// Check if the NSUserDefaults not contains the key then we register the default value
+		if (![keys containsObject:key])
+        	[self setValue:defaultSettings[key] forKey:key];
     }
 }
 

--- a/TOAppSettingsExample.xcodeproj/project.pbxproj
+++ b/TOAppSettingsExample.xcodeproj/project.pbxproj
@@ -15,6 +15,16 @@
 		22C6AA8720BC54CE008723DA /* TOAppSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 22BF240E209FE9C100416EC4 /* TOAppSettings.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		B1CD414A22674C0500BE4C00 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 22BF23EB209FE58500416EC4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 22C6AA7420BC53DC008723DA;
+			remoteInfo = TOAppSettingsExample;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		22BF240D209FE9C100416EC4 /* TOAppSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOAppSettings.h; sourceTree = "<group>"; };
 		22BF240E209FE9C100416EC4 /* TOAppSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOAppSettings.m; sourceTree = "<group>"; };
@@ -112,6 +122,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B1CD414B22674C0500BE4C00 /* PBXTargetDependency */,
 			);
 			name = TOAppSettingsTests;
 			productName = TOAppSettingsTests;
@@ -214,6 +225,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B1CD414B22674C0500BE4C00 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 22C6AA7420BC53DC008723DA /* TOAppSettingsExample */;
+			targetProxy = B1CD414A22674C0500BE4C00 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		22C6AA8020BC53DE008723DA /* LaunchScreen.storyboard */ = {

--- a/TOAppSettingsTests/TOAppSettingsTests.m
+++ b/TOAppSettingsTests/TOAppSettingsTests.m
@@ -32,7 +32,7 @@
 
 + (NSDictionary *)defaultPropertyValues
 {
-    return @{@"isDrunk": @YES};
+	return @{@"isDrunk": @YES, @"height": @(-1.05f)};
 }
 
 @end
@@ -81,6 +81,39 @@
     XCTAssert([settings.voiceActors[@"English"] isEqualToString:@"Justin Roiland"]);
     XCTAssert([[[NSString alloc] initWithData:settings.portalGunFormula encoding:NSUTF8StringEncoding] isEqualToString:@"McDonald's Szechuan McNugget Sauce"]);
     XCTAssert([settings.portalGunColor isEqual:[UIColor colorWithRed:0.0f green:1.0f blue:0.0f alpha:1.0f]]);
+}
+
+- (void)testDefaultValueUpdate {
+	
+	NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+	
+	// note: "className.ID.property"
+	
+	NSString * clsName = @"TestSettings";
+	NSString * identifier = @"DefValTest";
+
+	[defaults setObject:@"default-value"
+				 forKey:[NSString stringWithFormat:@"%@.%@.%@", clsName, identifier, @"Name"]];
+
+	[defaults setObject:@(42)
+				 forKey:[NSString stringWithFormat:@"%@.%@.%@", clsName, identifier, @"Age"]];
+
+	[defaults synchronize];
+	
+	// Set initial object, then dealloc
+	@autoreleasepool {
+		TestSettings * settings = [TestSettings settingsWithIdentifier:identifier];
+		settings = nil;
+	}
+	
+	// Get a second copy of the same instance and compare data was successfully retrieved
+	TestSettings * settings = [TestSettings settingsWithIdentifier:identifier];
+	
+	XCTAssert([settings.name isEqualToString:@"default-value"]);
+	XCTAssert(settings.age == 42);
+	
+	XCTAssert(settings.height == -1.05f);
+	XCTAssert(settings.isDrunk == YES);
 }
 
 // Test that two separate copies of the same object can be saved


### PR DESCRIPTION
Check the NSUserDefaults contains the key of default value instead of check the prefix.
iOS 9.0 not required, lowered to 8.0 