### PR TITLE
Improved efficiency

### DIFF
--- a/TOAppSettings/TOAppSettings.h
+++ b/TOAppSettings/TOAppSettings.h
@@ -1,7 +1,7 @@
 //
 //  TOAppSettings.h
 //
-//  Copyright 2018 Timothy Oliver. All rights reserved.
+//  Copyright 2018-2020 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOAppSettings/TOAppSettings.m
+++ b/TOAppSettings/TOAppSettings.m
@@ -1,7 +1,7 @@
 //
 //  TOAppSettings.m
 //
-//  Copyright 2018 Timothy Oliver. All rights reserved.
+//  Copyright 2018-2020 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to
@@ -340,7 +340,7 @@ static inline void TOAppSettingsReplaceAccessors(Class class, NSString *name, co
     
     SEL originalGetter = NSSelectorFromString(name);
     SEL originalSetter = NSSelectorFromString(setterName);
-    
+
     // If the class already has that selector, replace it.
     // Otherwise, add as a new method
     if ([class instancesRespondToSelector:originalGetter]) {

--- a/TOAppSettings/TOAppSettings.m
+++ b/TOAppSettings/TOAppSettings.m
@@ -403,12 +403,14 @@ static inline void TOAppSettingsSwapClassPropertyAccessors(Class class)
 
 /** A cache where previously created instances of the same
     settings objects are persisted. */
-+ (NSCache *)sharedCache
++ (NSMapTable *)sharedCache
 {
-    static NSCache *_cache;
+    static NSMapTable *_cache;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _cache = [[NSCache alloc] init];
+        _cache = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsCopyIn
+                                           valueOptions:NSPointerFunctionsWeakMemory
+                                               capacity:0];
     });
     return _cache;
 }

--- a/TOAppSettings/TOAppSettings.m
+++ b/TOAppSettings/TOAppSettings.m
@@ -336,10 +336,21 @@ static inline void TOAppSettingsReplaceAccessors(Class class, NSString *name, co
     if (newGetter == NULL || newSetter == NULL) { return; }
     
     // Generate synthesized setter method name
-    NSString *setterName = [NSString stringWithFormat:@"set%@%@:", [[name substringToIndex:1] capitalizedString], [name substringFromIndex:1]];
-    
+    NSString *setterName = [NSString stringWithFormat:@"set%@%@:",
+                            [[name substringToIndex:1] capitalizedString],
+                            [name substringFromIndex:1]];
+
+    // Convert the string names to selectors
     SEL originalGetter = NSSelectorFromString(name);
     SEL originalSetter = NSSelectorFromString(setterName);
+
+    // Compare the current implementations and skip if they match with the new ones
+    // (Eg, we've already replaced these implementations)
+    IMP originalGetterImplementation = class_getMethodImplementation(class, originalGetter);
+    IMP originalSetterImpelemtation = class_getMethodImplementation(class, originalSetter);
+    if (originalGetterImplementation == newGetter && originalSetterImpelemtation == newSetter) {
+        return;
+    }
 
     // If the class already has that selector, replace it.
     // Otherwise, add as a new method

--- a/TOAppSettingsExample.xcodeproj/project.pbxproj
+++ b/TOAppSettingsExample.xcodeproj/project.pbxproj
@@ -378,7 +378,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "TOAppSettingsTests/TOAppSettingsTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOAppSettingsExample.app/TOAppSettingsExample";
@@ -401,7 +400,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.timoliver.TOAppSettingsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "TOAppSettingsTests/TOAppSettingsTests-Bridging-Header.h";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOAppSettingsExample.app/TOAppSettingsExample";

--- a/TOAppSettingsTests/TOAppSettingsTests.m
+++ b/TOAppSettingsTests/TOAppSettingsTests.m
@@ -85,7 +85,7 @@
 
 - (void)testDefaultValueUpdate {
 	
-	NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	
 	// note: "className.ID.property"
 	
@@ -140,6 +140,25 @@
     TestSettings *first = [TestSettings defaultSettings];
     TestSettings *second = [TestSettings defaultSettings];
     XCTAssert(first == second);
+}
+
+// Test that if we create a settings object in an autoreleasepool
+- (void)testAutoreleaseCaching
+{
+    // Make a weak reference to the settings object
+    __weak TestSettings *weakSettings = nil;
+
+    // Make a new copy of the settings in an autoreleasepool,
+    // and save it to the weak reference
+    @autoreleasepool {
+        TestSettings *settings = [TestSettings defaultSettings];
+        weakSettings = settings;
+        settings = nil;
+    }
+
+    // At this point, after the autoreleasepool drained, the
+    // the weak reference should be nil
+    XCTAssertNil(weakSettings);
 }
 
 - (void)testDefaultPropertyValues


### PR DESCRIPTION
* Made class method swapping happen lazily on first init too avoid needing to iterate through every class at launch (Over 22,000 on iPadOS 14.3)
* Changed `NSCache` to `NSMapTable` as that was the assumed behaviour
* Updated unit tests to match expectations